### PR TITLE
changed quizzes variable visibility

### DIFF
--- a/contracts/CreateQuiz.sol
+++ b/contracts/CreateQuiz.sol
@@ -17,7 +17,7 @@ contract CreateQuiz is Ownable {
         uint8 languageCode;
     }
 
-    Quiz[] public quizzes;
+    Quiz[] internal quizzes;
 
     mapping (uint => bool) public quizzIsActive;
 


### PR DESCRIPTION
You do not need to explicitly set the keyword "internal" because it is the default keyword in Solidity.
I set "internal" just for us to pay attention to its visibility for practice.